### PR TITLE
Increased log level for the session manager and decreased it for thread pooling

### DIFF
--- a/distribution/src/resources/log4j2.xml
+++ b/distribution/src/resources/log4j2.xml
@@ -80,8 +80,12 @@
             <AppenderRef ref="console"/>
         </Logger>
 
+        <Logger name="org.jivesoftware.openfire.SessionManager" level="debug"/>
+
         <!-- OF-506: Jetty INFO messages are generally not useful. Ignore them by default. -->
         <Logger name="org.eclipse.jetty" level="warn"/>
+
+        <Logger name="org.apache.mina.filter.executor.OrderedThreadPoolExecutor" level="warn"/>
 
         <Root level="info">
             <AppenderRef ref="all-out"/>


### PR DESCRIPTION
I would like to setup some alarms for stream management and not pollute the log with thread pool events.