### PR TITLE
Initializing subscriptions for contacts of new users

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/openfire/roster/RosterManager.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/roster/RosterManager.java
@@ -596,6 +596,27 @@ public class RosterManager extends BasicModule implements GroupEventListener, Us
                 }
             }
         }
+
+        Log.info("Checking for roster items for a newly created account");
+        // See what contacts have that new user in their roster and try to subscribe to them
+        for (Iterator<String> it = getRosterItemProvider().getUsernames(newUserJID.toBareJID()); it.hasNext(); ) {
+            String user = it.next();
+            // Try to get a subscription to that new user
+            Log.info("Trying to subscribe {} to {}", user, newUserJID);
+            sendSubscribeRequest(server.createJID(user, null), newUserJID, true);
+            try {
+                Roster roster = getRoster(user);
+                RosterItem item = roster.getRosterItem(newUserJID);
+                // Set the subscription type to "from" so they can get a presence
+                if (item.subStatus == RosterItem.SubType.NONE) {
+                    Log.info("Pre-approving {} from", newUserJID, user);
+                    item.subStatus = RosterItem.SubType.FROM;
+                    roster.updateRosterItem(item);
+                }
+            } catch (UserNotFoundException e) {
+                Log.error("Cannot pre-approve subscription for new user {} in roster for {}, {}", newUserJID, user, e);
+            }
+        }
     }
 
     @Override

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/roster/RosterManager.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/roster/RosterManager.java
@@ -603,13 +603,12 @@ public class RosterManager extends BasicModule implements GroupEventListener, Us
             String user = it.next();
             // Try to get a subscription to that new user
             Log.info("Trying to subscribe {} to {}", user, newUserJID);
-            sendSubscribeRequest(server.createJID(user, null), newUserJID, true);
             try {
                 Roster roster = getRoster(user);
                 RosterItem item = roster.getRosterItem(newUserJID);
                 // Set the subscription type to "from" so they can get a presence
                 if (item.subStatus == RosterItem.SubType.NONE) {
-                    Log.info("Pre-approving {} from", newUserJID, user);
+                    Log.info("Pre-approving {} from {}", newUserJID, user);
                     item.subStatus = RosterItem.SubType.FROM;
                     roster.updateRosterItem(item);
                 }


### PR DESCRIPTION
# Intro

The case is following:
* A user adds a roster item that's still not a user
* The contact creates an account, but doesn't add the first user to their roster
* The first use doesn't see the second one

In this case, the subscription status in the first user's roster needs to be updated. And this is exactly what this PR does.