### PR TITLE
Null pointer for domain in StreamManagement when resuming

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/openfire/streammanagement/StreamManager.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/streammanagement/StreamManager.java
@@ -284,9 +284,9 @@ public class StreamManager {
         }
         final JID fullJid;
         if ( authToken.isAnonymous() ){
-            fullJid = new JID(resource, authToken.getDomain(), resource, true);
+            fullJid = new JID(resource, session.getServerName(), resource, true);
         } else {
-            fullJid = new JID(authToken.getUsername(), authToken.getDomain(), resource, true);
+            fullJid = new JID(authToken.getUsername(), session.getServerName(), resource, true);
         }
         Log.debug("Resuming session for '{}'. Current session: {}", fullJid, session.getStreamID());
 


### PR DESCRIPTION
# Introduction

I encountered the following exception:

```
2020.08.27 09:37:19 ERROR [socket_c2s-thread-5]: org.jivesoftware.openfire.nio.ConnectionHandler - Closing connection due to error while processing message: <resume xmlns="urn:xmpp:sm:3" previd="bWFpbgAyYmJhMHl5OWFk" h="13"/> 
java.lang.NullPointerException: Domain cannot be null 
at org.xmpp.packet.JID.<init>(JID.java:506) ~[tinder-2.0.0.jar:?] 
at org.jivesoftware.openfire.streammanagement.StreamManager.startResume(StreamManager.java:289) ~[xmppserver-4.6.0-SNAPSHOT.jar:4.6.0-SNAPSHOT] 
at org.jivesoftware.openfire.streammanagement.StreamManager.process(StreamManager.java:158) ~[xmppserver-4.6.0-SNAPSHOT.jar:4.6.0-SNAPSHOT] 
at org.jivesoftware.openfire.net.StanzaHandler.process(StanzaHandler.java:200) ~[xmppserver-4.6.0-SNAPSHOT.jar:4.6.0-SNAPSHOT] 
at org.jivesoftware.openfire.nio.ConnectionHandler.messageReceived(ConnectionHandler.java:183) [xmppserver-4.6.0-SNAPSHOT.jar:4.6.0-SNAPSHOT] 
at org.apache.mina.core.filterchain.DefaultIoFilterChain$TailFilter.messageReceived(DefaultIoFilterChain.java:1015) [mina-core-2.1.3.jar:?] 
at org.apache.mina.core.filterchain.DefaultIoFilterChain.callNextMessageReceived(DefaultIoFilterChain.java:650) [mina-core-2.1.3.jar:?] 
at org.apache.mina.core.filterchain.DefaultIoFilterChain.access$1300(DefaultIoFilterChain.java:49) [mina-core-2.1.3.jar:?] 
at org.apache.mina.core.filterchain.DefaultIoFilterChain$EntryImpl$1.messageReceived(DefaultIoFilterChain.java:1128) [mina-core-2.1.3.jar:?] 
at org.apache.mina.core.filterchain.IoFilterAdapter.messageReceived(IoFilterAdapter.java:122) [mina-core-2.1.3.jar:?] 
at org.apache.mina.core.filterchain.DefaultIoFilterChain.callNextMessageReceived(DefaultIoFilterChain.java:650) [mina-core-2.1.3.jar:?] 
at org.apache.mina.core.filterchain.DefaultIoFilterChain.access$1300(DefaultIoFilterChain.java:49) [mina-core-2.1.3.jar:?] 
at org.apache.mina.core.filterchain.DefaultIoFilterChain$EntryImpl$1.messageReceived(DefaultIoFilterChain.java:1128) [mina-core-2.1.3.jar:?] 
at org.apache.mina.filter.codec.ProtocolCodecFilter$ProtocolDecoderOutputImpl.flush(ProtocolCodecFilter.java:413) [mina-core-2.1.3.jar:?] 
at org.apache.mina.filter.codec.ProtocolCodecFilter.messageReceived(ProtocolCodecFilter.java:257) [mina-core-2.1.3.jar:?] 
at org.apache.mina.core.filterchain.DefaultIoFilterChain.callNextMessageReceived(DefaultIoFilterChain.java:650) [mina-core-2.1.3.jar:?] 
at org.apache.mina.core.filterchain.DefaultIoFilterChain.access$1300(DefaultIoFilterChain.java:49) [mina-core-2.1.3.jar:?] 
at org.apache.mina.core.filterchain.DefaultIoFilterChain$EntryImpl$1.messageReceived(DefaultIoFilterChain.java:1128) [mina-core-2.1.3.jar:?] 
at org.apache.mina.core.filterchain.IoFilterEvent.fire(IoFilterEvent.java:106) [mina-core-2.1.3.jar:?] 
at org.apache.mina.core.session.IoEvent.run(IoEvent.java:89) [mina-core-2.1.3.jar:?] 
at org.apache.mina.filter.executor.OrderedThreadPoolExecutor$Worker.runTask(OrderedThreadPoolExecutor.java:766) [mina-core-2.1.3.jar:?] 
at org.apache.mina.filter.executor.OrderedThreadPoolExecutor$Worker.runTasks(OrderedThreadPoolExecutor.java:758) [mina-core-2.1.3.jar:?] 
at org.apache.mina.filter.executor.OrderedThreadPoolExecutor$Worker.run(OrderedThreadPoolExecutor.java:697) [mina-core-2.1.3.jar:?] 
at java.lang.Thread.run(Unknown Source) [?:?] 
```

in the following scenario:

* A client disconnects ungracefully
* The same client then reconnects and tries to resume its session via stream management
* Openfire starts the process of resuming and tries to create a JID for that client here:

```
fullJid = new JID(authToken.getUsername(), authToken.getDomain(), resource, true);
```

However, `getDomain` is a deprecated method that looks at the `xmpp.domain` system property, which is null.
This property is being deleted by `XMPPServer` because the value in the XML configuration should be used instead.

# My solution

I opted to use `session.getServerName()` because the session is already available there, had the most recent and correct data and in fact, the same method is used in many other places to the same effect.