### PR TITLE
Not removing disconnected users from groups

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/openfire/muc/MultiUserChatManager.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/muc/MultiUserChatManager.java
@@ -869,18 +869,20 @@ public class MultiUserChatManager extends BasicModule implements ClusterEventLis
 
     @Override
     public void leftCluster(byte[] nodeID) {
-        // Remove all room occupants linked to the defunct node as their sessions are cleaned out earlier
-        Log.debug("Removing orphaned occupants associated with defunct node: " +  new String(nodeID, StandardCharsets.UTF_8));
-
-        for (MultiUserChatService service : getMultiUserChatServices()) {
-            for (MUCRoom mucRoom : service.getChatRooms()) {
-                for (MUCRole mucRole : mucRoom.getOccupants()) {
-                    if (mucRole.getNodeID().equals(nodeID)) {
-                        mucRoom.leaveRoom(mucRole);
-                    }
-                }
-            }
-        }
+        // Even though it's against the standard, don't remove participants from the group if
+        // they disconnect
+//        // Remove all room occupants linked to the defunct node as their sessions are cleaned out earlier
+//        Log.debug("Removing orphaned occupants associated with defunct node: " +  new String(nodeID, StandardCharsets.UTF_8));
+//
+//        for (MultiUserChatService service : getMultiUserChatServices()) {
+//            for (MUCRoom mucRoom : service.getChatRooms()) {
+//                for (MUCRole mucRole : mucRoom.getOccupants()) {
+//                    if (mucRole.getNodeID().equals(nodeID)) {
+//                        mucRoom.leaveRoom(mucRole);
+//                    }
+//                }
+//            }
+//        }
     }
 
     @Override

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/muc/spi/LocalMUCUser.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/muc/spi/LocalMUCUser.java
@@ -542,8 +542,10 @@ public class LocalMUCUser implements MUCUser {
                         try {
                             // TODO Consider that different nodes can be creating and processing this presence at the same time (when remote node went down)
                             role.setPresence(packet);
-                            removeRole(group);
-                            role.getChatRoom().leaveRoom(role);
+                            // Even though it's against the standard, don't remove participants from the group if
+                            // they disconnect
+//                            removeRole(group);
+//                            role.getChatRoom().leaveRoom(role);
                         }
                         catch (Exception e) {
                             Log.error(e.getMessage(), e);

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/muc/spi/RemoteMUCUser.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/muc/spi/RemoteMUCUser.java
@@ -66,10 +66,12 @@ public class RemoteMUCUser implements MUCUser {
 
     private void process(Presence presence) {
         if (presence.getType() == Presence.Type.unavailable) {
-            MUCRole mucRole = room.getOccupantByFullJID(realjid);
-            if (mucRole != null) {
-                room.leaveRoom(mucRole);
-            }
+            // Even though it's against the standard, don't remove participants from the group if
+            // they disconnect
+//            MUCRole mucRole = room.getOccupantByFullJID(realjid);
+//            if (mucRole != null) {
+//                room.leaveRoom(mucRole);
+//            }
         }
         else {
             throw new UnsupportedOperationException("Cannot process Presence packets of remote users: " + presence);


### PR DESCRIPTION
# Introduction

Removing disconnected users from group chats is a problem for mobile since the devices are mostly offline, but they still want to receive chat updates.

That's why here I'm breaking the XMPP standard a little bit by not disconnecting them.