### PR TITLE
Added self-signed certificate creation to dockerfiles

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,14 +3,18 @@ FROM amazon/aws-cli as aws
 # download push notification credentials from S3
 RUN --mount=type=secret,id=aws,target=/root/.aws/credentials aws s3 cp s3://com.feinfone.build/apns/apns_key.p8 /usr/local/openfire/authKey.p8
 
-# TODO probably pass build arguments with docker-compose
+# Maven target to get all dependencies
+FROM maven:3.6.2-jdk-11 as packager
+
+# TODO define values via command
+# define the build arguments
 ARG VERSION_DBACCESS=1.2.2
 ARG VERSION_REGISTRATION=1.7.2
 ARG VERSION_RESTAPI=1.4.0
 ARG VERSION_SUBSCRIPTION=1.4.0
 
-# Maven target to get all dependencies
-FROM maven:3.6.2-jdk-11 as packager
+ARG KEYSTORE_PWD
+
 WORKDIR /usr/src
 
 COPY ./pom.xml .
@@ -22,6 +26,30 @@ COPY ./plugins/pom.xml ./plugins/
 COPY ./plugins/openfire-plugin-assembly-descriptor/pom.xml ./plugins/openfire-plugin-assembly-descriptor/
 COPY ./distribution/pom.xml ./distribution/
 
+WORKDIR ca
+# create self signed certificate and add it to a PKCS12 keystore
+RUN keytool -genkeypair \
+        -keystore keystore.p12 \
+        -deststoretype pkcs12 \
+        -dname "CN=feinfone.com" \
+        -keypass ${KEYSTORE_PWD} \
+        -storepass ${KEYSTORE_PWD} \
+        -keyalg RSA \
+        -validity 365 \
+        -keysize 4096 \
+        -alias feinfone.com \
+        # multi domain certificate part
+        -ext SAN=dns:feinfone.com,dns:search.feinfone.com,dns:proxy.feinfone.com,dns:pubsub.feinfone.com,dns:conference.feinfone.com \
+    # to add another certificate to the same keystore just copy paste the previous command again with a different alias
+    # Convert PKCS12 keystore to a JKS keystore which Openfire understands
+    && keytool -importkeystore \
+               -srckeystore keystore.p12 \
+               -srcstoretype PKCS12 \
+               -srcstorepass ${KEYSTORE_PWD} \
+               -destkeystore keystore \
+               -deststorepass ${KEYSTORE_PWD}
+
+WORKDIR /usr/src
 # get all necessary plugins
 # 1. official plugins
 # DB Access (Official Openfire plugin)
@@ -65,6 +93,9 @@ COPY build/docker/inject_db_settings.sh \
 
 # copy push notification credentials
 COPY --from=aws /usr/local/openfire/authKey.p8 .
+# copy self signed certificate
+COPY --from=packager /usr/src/ca/chat_server.crt ./resources/security/keystore
+# COPY --from=packager /usr/src/ca/chat_priv.key /usr/local/openfire/resources/security/keystore
 
 # (move all plugin JARs to the plugin folder)
 COPY --from=packager /usr/src/plugins/openfire-avatar-upload-plugin/target/avatarupload-0.0.1-SNAPSHOT.jar \

--- a/Dockerfile
+++ b/Dockerfile
@@ -99,7 +99,7 @@ COPY --from=packager /usr/src/ca/keystore ./resources/security/
 
 # (move all plugin JARs to the plugin folder)
 COPY --from=packager /usr/src/plugins/openfire-avatar-upload-plugin/target/avatarupload-0.0.1-SNAPSHOT.jar \
-     /usr/src/plugins/openfire-voice-plugin/target/voice-0.0.11-SNAPSHOT.jar \
+     /usr/src/plugins/openfire-voice-plugin/target/voice-0.1.0-SNAPSHOT.jar \
      /usr/src/plugins/openfire-apns/target/openfire-apns.jar \
      /usr/src/plugins/openfire-hazelcast-plugin/target/hazelcast-2.4.2-SNAPSHOT.jar \
      ./plugins/

--- a/Dockerfile
+++ b/Dockerfile
@@ -39,7 +39,7 @@ RUN keytool -genkeypair \
         -keysize 4096 \
         -alias feinfone.com \
         # multi domain certificate part
-        -ext SAN=dns:feinfone.com,dns:search.feinfone.com,dns:proxy.feinfone.com,dns:pubsub.feinfone.com,dns:conference.feinfone.com \
+        -ext SAN=dns:feinfone.com,dns:search.feinfone.com,dns:proxy.feinfone.com,dns:pubsub.feinfone.com,dns:conference.feinfone.com,dns:group-chat.feinfone.com \
     # to add another certificate to the same keystore just copy paste the previous command again with a different alias
     # Convert PKCS12 keystore to a JKS keystore which Openfire understands
     && keytool -importkeystore \
@@ -93,9 +93,9 @@ COPY build/docker/inject_db_settings.sh \
 
 # copy push notification credentials
 COPY --from=aws /usr/local/openfire/authKey.p8 .
-# copy self signed certificate
-COPY --from=packager /usr/src/ca/chat_server.crt ./resources/security/keystore
-# COPY --from=packager /usr/src/ca/chat_priv.key /usr/local/openfire/resources/security/keystore
+
+# copy keystore with self signed certificate
+COPY --from=packager /usr/src/ca/keystore ./resources/security/
 
 # (move all plugin JARs to the plugin folder)
 COPY --from=packager /usr/src/plugins/openfire-avatar-upload-plugin/target/avatarupload-0.0.1-SNAPSHOT.jar \

--- a/Dockerfile_local
+++ b/Dockerfile_local
@@ -61,7 +61,7 @@ RUN wget https://www.igniterealtime.org/projects/openfire/plugins/${VERSION_DBAC
 # REST API
  && wget https://www.igniterealtime.org/projects/openfire/plugins/${VERSION_RESTAPI}/restAPI.jar -O ./plugins/restAPI.jar \
 # Subscription
- && wget https://www.igniterealtime.org/projects/openfire/plugins/${VERSION_SUBSCRIPTION}/subscription.jar -O ./plugins/subscription.jar \
+ && wget https://www.igniterealtime.org/projects/openfire/plugins/${VERSION_SUBSCRIPTION}/subscription.jar -O ./plugins/subscription.jar
 
 # 2. take all plugins developed by us from the parent directory
 COPY ./openfire-apns ./plugins/openfire-apns

--- a/Dockerfile_local
+++ b/Dockerfile_local
@@ -14,7 +14,6 @@ ARG VERSION_DBACCESS=1.2.2
 ARG VERSION_REGISTRATION=1.7.2
 ARG VERSION_RESTAPI=1.4.0
 ARG VERSION_SUBSCRIPTION=1.4.0
-ARG VERSION_JUSTMARRIED=1.2.2
 
 ARG KEYSTORE_PWD=testpass
 
@@ -42,7 +41,7 @@ RUN keytool -genkeypair \
         -keysize 4096 \
         -alias feinfone.com \
         # multi domain certificate part
-        -ext SAN=dns:feinfone.com,dns:search.feinfone.com,dns:proxy.feinfone.com,dns:pubsub.feinfone.com,dns:conference.feinfone.com \
+        -ext SAN=dns:feinfone.com,dns:search.feinfone.com,dns:proxy.feinfone.com,dns:pubsub.feinfone.com,dns:conference.feinfone.com,dns:group-chat.feinfone.com \
     # to add another certificate to the same keystore just copy paste the previous command again with a different alias
     # Convert PKCS12 keystore to a JKS keystore which Openfire understands
     && keytool -importkeystore \
@@ -63,8 +62,6 @@ RUN wget https://www.igniterealtime.org/projects/openfire/plugins/${VERSION_DBAC
  && wget https://www.igniterealtime.org/projects/openfire/plugins/${VERSION_RESTAPI}/restAPI.jar -O ./plugins/restAPI.jar \
 # Subscription
  && wget https://www.igniterealtime.org/projects/openfire/plugins/${VERSION_SUBSCRIPTION}/subscription.jar -O ./plugins/subscription.jar \
-# Just married
- && wget https://www.igniterealtime.org/projects/openfire/plugins/${VERSION_JUSTMARRIED}/justmarried.jar -O ./plugins/justmarried.jar
 
 # 2. take all plugins developed by us from the parent directory
 COPY ./openfire-apns ./plugins/openfire-apns
@@ -94,7 +91,7 @@ COPY Openfire/build/docker/inject_db_settings.sh \
 # copy push notification credentials
 COPY --from=aws /usr/local/openfire/authKey.p8 .
 
-# copy self signed certificate
+# copy keystore with self signed certificate
 COPY --from=packager /usr/src/ca/keystore ./resources/security/
 
 # (move all plugin JARs to the plugin folder)

--- a/Dockerfile_local
+++ b/Dockerfile_local
@@ -3,8 +3,21 @@ FROM amazon/aws-cli as aws
 # download push notification credentials from S3
 RUN --mount=type=secret,id=aws,target=/root/.aws/credentials aws s3 cp s3://com.feinfone.build/apns/apns_key.p8 /usr/local/openfire/authKey.p8
 
-# Maven target to get all dependencies
+#ARG KEYSTORE_PASS=testpass
+#ARG KEYSTORE_ALIAS="feinfone.com"
+
+# Maven target to get all dependencies and build
 FROM maven:3.6.2-jdk-11 as packager
+
+# define the build arguments
+ARG VERSION_DBACCESS=1.2.2
+ARG VERSION_REGISTRATION=1.7.2
+ARG VERSION_RESTAPI=1.4.0
+ARG VERSION_SUBSCRIPTION=1.4.0
+ARG VERSION_JUSTMARRIED=1.2.2
+
+ARG KEYSTORE_PWD=testpass
+
 WORKDIR /usr/src
 
 COPY Openfire/pom.xml .
@@ -16,16 +29,42 @@ COPY Openfire/plugins/pom.xml ./plugins/
 COPY Openfire/plugins/openfire-plugin-assembly-descriptor/pom.xml ./plugins/openfire-plugin-assembly-descriptor/
 COPY Openfire/distribution/pom.xml ./distribution/
 
+WORKDIR ca
+# create self signed certificate and add it to a PKCS12 keystore
+RUN keytool -genkeypair \
+        -keystore keystore.p12 \
+        -deststoretype pkcs12 \
+        -dname "CN=feinfone.com" \
+        -keypass ${KEYSTORE_PWD} \
+        -storepass ${KEYSTORE_PWD} \
+        -keyalg RSA \
+        -validity 365 \
+        -keysize 4096 \
+        -alias feinfone.com \
+        # multi domain certificate part
+        -ext SAN=dns:feinfone.com,dns:search.feinfone.com,dns:proxy.feinfone.com,dns:pubsub.feinfone.com,dns:conference.feinfone.com \
+    # to add another certificate to the same keystore just copy paste the previous command again with a different alias
+    # Convert PKCS12 keystore to a JKS keystore which Openfire understands
+    && keytool -importkeystore \
+               -srckeystore keystore.p12 \
+               -srcstoretype PKCS12 \
+               -srcstorepass ${KEYSTORE_PWD} \
+               -destkeystore keystore \
+               -deststorepass ${KEYSTORE_PWD}
+
+WORKDIR /usr/src
 # get all necessary plugins
 # 1. official plugins
-# DB Access (Official Openfire plugin)
+# DB Access
 RUN wget https://www.igniterealtime.org/projects/openfire/plugins/${VERSION_DBACCESS}/dbaccess.jar -O ./plugins/dbaccess.jar \
-# Registration (Official Openfire plugin)
+# Registration
  && wget https://www.igniterealtime.org/projects/openfire/plugins/${VERSION_REGISTRATION}/registration.jar -O ./plugins/registration.jar \
-# REST API (Official Openfire plugin)
+# REST API
  && wget https://www.igniterealtime.org/projects/openfire/plugins/${VERSION_RESTAPI}/restAPI.jar -O ./plugins/restAPI.jar \
-# Subscription (Official Openfire plugin)
- && wget https://www.igniterealtime.org/projects/openfire/plugins/${VERSION_SUBSCRIPTION}/subscription.jar -O ./plugins/subscription.jar
+# Subscription
+ && wget https://www.igniterealtime.org/projects/openfire/plugins/${VERSION_SUBSCRIPTION}/subscription.jar -O ./plugins/subscription.jar \
+# Just married
+ && wget https://www.igniterealtime.org/projects/openfire/plugins/${VERSION_JUSTMARRIED}/justmarried.jar -O ./plugins/justmarried.jar
 
 # 2. take all plugins developed by us from the parent directory
 COPY ./openfire-apns ./plugins/openfire-apns
@@ -55,6 +94,9 @@ COPY Openfire/build/docker/inject_db_settings.sh \
 # copy push notification credentials
 COPY --from=aws /usr/local/openfire/authKey.p8 .
 
+# copy self signed certificate
+COPY --from=packager /usr/src/ca/keystore ./resources/security/
+
 # (move all plugin JARs to the plugin folder)
 COPY --from=packager /usr/src/plugins/openfire-avatar-upload-plugin/target/avatarupload-0.0.1-SNAPSHOT.jar \
     /usr/src/plugins/openfire-voice-plugin/target/voice-0.0.11-SNAPSHOT.jar \
@@ -67,7 +109,7 @@ ENV OPENFIRE_USER=openfire \
     OPENFIRE_DATA_DIR=/var/lib/openfire \
     OPENFIRE_LOG_DIR=/var/log/openfire
 
-RUN apt-get update -qq \
+RUN apt-get update -qq --allow-releaseinfo-change \
     && apt-get install -yqq sudo \
     && adduser --disabled-password --quiet --system --home $OPENFIRE_DATA_DIR --gecos "Openfire XMPP server" --group openfire \
     && chmod 755 /sbin/entrypoint.sh \

--- a/Dockerfile_local
+++ b/Dockerfile_local
@@ -96,7 +96,7 @@ COPY --from=packager /usr/src/ca/keystore ./resources/security/
 
 # (move all plugin JARs to the plugin folder)
 COPY --from=packager /usr/src/plugins/openfire-avatar-upload-plugin/target/avatarupload-0.0.1-SNAPSHOT.jar \
-    /usr/src/plugins/openfire-voice-plugin/target/voice-0.0.11-SNAPSHOT.jar \
+    /usr/src/plugins/openfire-voice-plugin/target/voice-0.1.0-SNAPSHOT.jar \
     /usr/src/plugins/openfire-apns/target/openfire-apns.jar \
     # add new plugins here
     /usr/src/plugins/openfire-hazelcast-plugin/target/hazelcast-2.4.2-SNAPSHOT.jar ./plugins/

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Other folders are:
 #### Docker build
 To build the complete project including plugins, run the command (only docker build supported).
 ```
-DOCKER_BUILDKIT=1 docker build --ssh default --secret id=aws,src=$HOME/.aws/credentials .
+DOCKER_BUILDKIT=1 docker build --ssh default --secret id=aws,src=$HOME/.aws/credentials --build-arg KEYSTORE_PWD=changeit .
 ```
 Executing this command will forward your local SSH key (via SSH agent) and your AWS credentials to the docker build.
 


### PR DESCRIPTION
### Problem
Openfire requires a keystore with a certificate for secure communication but so far the Dockerfiles did not build an Openfire image containing this keystore.

### Solution
A self-signed multi-domaine certificate (SAN certificate) will be created when the docker image will be created.
The password for the local build is just _testpass_  and for the stage/production build it must be provided via command.