### PR TITLE
Fixed build with Hazelcast and AWS Fargate discovery

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -87,8 +87,9 @@ COPY --from=packager /usr/src/ca/keystore ./resources/security/
 COPY --from=packager /usr/src/plugins/openfire-avatar-upload-plugin/target/avatarupload.jar \
      /usr/src/plugins/openfire-voice-plugin/target/voice.jar \
      /usr/src/plugins/openfire-apns/target/openfire-apns.jar \
-     /usr/src/plugins/openfire-hazelcast-plugin/target/hazelcast-openfire-plugin-assembly.jar \
      ./plugins/
+
+COPY --from=packager /usr/src/plugins/openfire-hazelcast-plugin/target/hazelcast-openfire-plugin-assembly.jar ./plugins/hazelcast.jar
 
 ENV OPENFIRE_USER=openfire \
     OPENFIRE_DIR=/usr/local/openfire \

--- a/Dockerfile_local
+++ b/Dockerfile_local
@@ -81,14 +81,16 @@ COPY --from=packager /usr/src/plugins/openfire-avatar-upload-plugin/target/avata
     /usr/src/plugins/openfire-voice-plugin/target/voice.jar \
     /usr/src/plugins/openfire-apns/target/openfire-apns.jar \
     # add new plugins here
-    /usr/src/plugins/openfire-hazelcast-plugin/target/hazelcast-openfire-plugin-assembly.jar ./plugins/
+    ./plugins/
+
+COPY --from=packager /usr/src/plugins/openfire-hazelcast-plugin/target/hazelcast-openfire-plugin-assembly.jar ./plugins/hazelcast.jar
 
 ENV OPENFIRE_USER=openfire \
     OPENFIRE_DIR=/usr/local/openfire \
     OPENFIRE_DATA_DIR=/var/lib/openfire \
     OPENFIRE_LOG_DIR=/var/log/openfire
 
-RUN apt-get update -qq --allow-releaseinfo-change \
+RUN apt-get update -qq \
     && apt-get install -yqq sudo \
     && adduser --disabled-password --quiet --system --home $OPENFIRE_DATA_DIR --gecos "Openfire XMPP server" --group openfire \
     && chmod 755 /sbin/entrypoint.sh \

--- a/README.md
+++ b/README.md
@@ -73,9 +73,13 @@ Other folders are:
 #### Docker build
 To build the complete project including plugins, run the command (only docker build supported).
 ```
-DOCKER_BUILDKIT=1 docker build --ssh default --secret id=aws,src=$HOME/.aws/credentials --build-arg KEYSTORE_PWD=changeit .
+docker buildx build --ssh default --secret id=aws,src=$HOME/.aws/credentials --build-arg KEYSTORE_PWD=changeit .
 ```
 Executing this command will forward your local SSH key (via SSH agent) and your AWS credentials to the docker build.
+Alternatively you can you this command to tag your image when building it whit this command:
+```
+docker buildx build --ssh default --secret id=aws,src=$HOME/.aws/credentials --build-arg KEYSTORE_PWD=changeit -t 556016385979.dkr.ecr.eu-central-1.amazonaws.com/feinfone:<image-version> .
+``` 
 
 ##### Prerequisites
 To forward your SSH key pair it has to be generated (default file name) and added to your GitHub account.

--- a/README.md
+++ b/README.md
@@ -76,10 +76,6 @@ To build the complete project including plugins, run the command (only docker bu
 docker buildx build --ssh default --secret id=aws,src=$HOME/.aws/credentials --build-arg KEYSTORE_PWD=changeit .
 ```
 Executing this command will forward your local SSH key (via SSH agent) and your AWS credentials to the docker build.
-Alternatively you can use this command to tag your image when building it whit this command:
-```
-docker buildx build --ssh default --secret id=aws,src=$HOME/.aws/credentials --build-arg KEYSTORE_PWD=changeit -t 556016385979.dkr.ecr.eu-central-1.amazonaws.com/feinfone:<image-version> .
-``` 
 
 ##### Prerequisites
 To forward your SSH key pair it has to be generated (default file name) and added to your GitHub account.

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ To build the complete project including plugins, run the command (only docker bu
 docker buildx build --ssh default --secret id=aws,src=$HOME/.aws/credentials --build-arg KEYSTORE_PWD=changeit .
 ```
 Executing this command will forward your local SSH key (via SSH agent) and your AWS credentials to the docker build.
-Alternatively you can you this command to tag your image when building it whit this command:
+Alternatively you can use this command to tag your image when building it whit this command:
 ```
 docker buildx build --ssh default --secret id=aws,src=$HOME/.aws/credentials --build-arg KEYSTORE_PWD=changeit -t 556016385979.dkr.ecr.eu-central-1.amazonaws.com/feinfone:<image-version> .
 ``` 

--- a/build/docker/template_openfire.xml
+++ b/build/docker/template_openfire.xml
@@ -62,6 +62,9 @@
         </defaultProvider>
         <mysql>
             <useUnicode>true</useUnicode>
-        </mysql>>
+        </mysql>
     </database>
+    <clustering>
+        <enabled>true</enabled>
+    </clustering>
 </jive>


### PR DESCRIPTION
Because of the broken dependency in our [Openfire Hazelcast Plugin Fork](https://github.com/nsobadzhiev/openfire-hazelcast-plugin) with the com.ikentoo hazelcast-aws-ecs library SNAPSHOT-0.0.1 it was added as a system file dependency.
Further problems with creating the Openfire docker image including the Hazelcast plugin are addressed in this pull request.