### PR TITLE
Use our registration plugin

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,8 +42,6 @@ WORKDIR /usr/src
 # 1. official plugins
 # DB Access (Official Openfire plugin)
 RUN wget https://www.igniterealtime.org/projects/openfire/plugins/${VERSION_DBACCESS}/dbaccess.jar -O ./plugins/dbaccess.jar \
-# Registration (Official Openfire plugin)
- && wget https://www.igniterealtime.org/projects/openfire/plugins/${VERSION_REGISTRATION}/registration.jar -O ./plugins/registration.jar \
 # REST API (Official Openfire plugin)
  && wget https://www.igniterealtime.org/projects/openfire/plugins/${VERSION_RESTAPI}/restAPI.jar -O ./plugins/restAPI.jar \
 # Subscription (Official Openfire plugin)
@@ -60,6 +58,8 @@ RUN --mount=type=ssh git clone git@github.com:voiceup-chat/openfire-avatar-uploa
  && git clone git@github.com:voiceup-chat/openfire-apns.git ./plugins/openfire-apns \
 # [Feinfone APNS](https://github.com/voiceup-chat/openfire-apns)
  && git clone git@github.com:nsobadzhiev/openfire-hazelcast-plugin.git ./plugins/openfire-hazelcast-plugin
+# [Feinfone Registration](https://github.com/nsobadzhiev/openfire-registration-plugin)
+ && git clone git@github.com:nsobadzhiev/openfire-registration-plugin.git ./plugins/openfire-registration-plugin
 
 RUN mvn dependency:go-offline
 

--- a/Dockerfile_local
+++ b/Dockerfile_local
@@ -8,6 +8,8 @@ RUN --mount=type=secret,id=aws,target=/root/.aws/credentials aws s3 cp s3://com.
 # Maven target to get all dependencies and build
 FROM maven:3.6.2-jdk-11 as packager
 # build arguments
+ARG PROJECT_FOLDER=Openfire
+
 ARG VERSION_DBACCESS=1.2.2
 ARG VERSION_REGISTRATION=1.7.2
 ARG VERSION_RESTAPI=1.4.0
@@ -17,14 +19,14 @@ ARG KEYSTORE_PWD=changeit
 
 WORKDIR /usr/src
 
-COPY Openfire/pom.xml .
-COPY Openfire/i18n/pom.xml ./i18n/
-COPY Openfire/xmppserver/pom.xml ./xmppserver/
-COPY Openfire/starter/pom.xml ./starter/
-COPY Openfire/starter/libs/* ./starter/libs/
-COPY Openfire/plugins/pom.xml ./plugins/
-COPY Openfire/plugins/openfire-plugin-assembly-descriptor/pom.xml ./plugins/openfire-plugin-assembly-descriptor/
-COPY Openfire/distribution/pom.xml ./distribution/
+COPY $PROJECT_FOLDER/pom.xml .
+COPY $PROJECT_FOLDER/i18n/pom.xml ./i18n/
+COPY $PROJECT_FOLDER/xmppserver/pom.xml ./xmppserver/
+COPY $PROJECT_FOLDER/starter/pom.xml ./starter/
+COPY $PROJECT_FOLDER/starter/libs/* ./starter/libs/
+COPY $PROJECT_FOLDER/plugins/pom.xml ./plugins/
+COPY $PROJECT_FOLDER/plugins/openfire-plugin-assembly-descriptor/pom.xml ./plugins/openfire-plugin-assembly-descriptor/
+COPY $PROJECT_FOLDER/distribution/pom.xml ./distribution/
 
 WORKDIR ca
 # copy the certificate from aws build stage and create a keystore with it
@@ -40,8 +42,6 @@ WORKDIR /usr/src
 # 1. official plugins
 # DB Access
 RUN wget https://www.igniterealtime.org/projects/openfire/plugins/${VERSION_DBACCESS}/dbaccess.jar -O ./plugins/dbaccess.jar \
-# Registration
- && wget https://www.igniterealtime.org/projects/openfire/plugins/${VERSION_REGISTRATION}/registration.jar -O ./plugins/registration.jar \
 # REST API
  && wget https://www.igniterealtime.org/projects/openfire/plugins/${VERSION_RESTAPI}/restAPI.jar -O ./plugins/restAPI.jar \
 # Subscription
@@ -52,24 +52,28 @@ COPY ./openfire-apns ./plugins/openfire-apns
 COPY ./openfire-voice-plugin ./plugins/openfire-voice-plugin
 COPY ./openfire-avatar-upload-plugin ./plugins/openfire-avatar-upload-plugin
 COPY ./openfire-hazelcast-plugin ./plugins/openfire-hazelcast-plugin
+COPY ./openfire-registration-plugin ./plugins/openfire-registration-plugin
 # add new plugins here
 
 RUN mvn dependency:go-offline
 
-COPY Openfire .
+COPY $PROJECT_FOLDER .
 RUN mvn package
 
 # build target
 FROM openjdk:11-jre-slim as build
+# build arguments
+ARG PROJECT_FOLDER=Openfire
+
 WORKDIR /usr/local/openfire
 COPY --from=packager /usr/src/distribution/target/distribution-base .
 COPY --from=packager /usr/src/build/docker/entrypoint_local.sh /sbin/entrypoint.sh
 
-COPY Openfire/build/docker/inject_db_settings.sh \
-     Openfire/build/docker/inject_hazelcast_settings.sh \
-     Openfire/build/docker/template_openfire.xml \
-     Openfire/build/docker/template_hazelcast.xml \
-     Openfire/build/docker/template_security.xml \
+COPY $PROJECT_FOLDER/build/docker/inject_db_settings.sh \
+     $PROJECT_FOLDER/build/docker/inject_hazelcast_settings.sh \
+     $PROJECT_FOLDER/build/docker/template_openfire.xml \
+     $PROJECT_FOLDER/build/docker/template_hazelcast.xml \
+     $PROJECT_FOLDER/build/docker/template_security.xml \
      ./
 
 # copy push notification credentials

--- a/README.md
+++ b/README.md
@@ -107,10 +107,11 @@ docker-compose -f infra.yml up
 
 To build a docker image that contains all plugins and can be locally tested **all plugins and this project have to be
 contained in the same folder on your disk.**
-Run the following command to create a docker image with remote debugging support:
+Run the following command in the parent directory of this project and replace `<project_folder>` with the name of the folder this project has been cloned to.
 ```
-DOCKER_BUILDKIT=1 docker build -t openfire:latest --secret id=aws,src=$HOME/.aws/credentials -f Openfire/Dockerfile_local .
+DOCKER_BUILDKIT=1 docker build -t openfire:latest --secret id=aws,src=$HOME/.aws/credentials -f <poject_folder>/Dockerfile_local --build-arg PROJECT_FOLDER=<project_folder> .
 ```
+This will create a docker image with remote debugging support on port 5005 suspending the JVM until a debugger connected.
 
 If a new plugin needs to be added it has to be added to **Dockerfile_local**.
 First the plugin folder needs to be copied to the **packager** image.

--- a/build/docker/entrypoint.sh
+++ b/build/docker/entrypoint.sh
@@ -74,6 +74,7 @@ if [[ -z ${1} ]]; then
         -Dopenfire.lib.dir=${OPENFIRE_DIR}/lib \
         -Dlog4j.configurationFile=${OPENFIRE_DIR}/lib/log4j2.xml \
         -Djavax.net.ssl.trustStore=${OPENFIRE_DIR}/resources/security/truststore \
+        -Dxmpp.socket.ssl.active=true \
         -classpath ${OPENFIRE_DIR}/lib/startup.jar \
         -jar ${OPENFIRE_DIR}/lib/startup.jar ${EXTRA_ARGS}
 else

--- a/build/docker/entrypoint_local.sh
+++ b/build/docker/entrypoint_local.sh
@@ -75,6 +75,7 @@ if [[ -z ${1} ]]; then
         -Dopenfire.lib.dir=${OPENFIRE_DIR}/lib \
         -Dlog4j.configurationFile=${OPENFIRE_DIR}/lib/log4j2.xml \
         -Djavax.net.ssl.trustStore=${OPENFIRE_DIR}/resources/security/truststore \
+        -Dxmpp.socket.ssl.active=true \
         -classpath ${OPENFIRE_DIR}/lib/startup.jar \
         -jar ${OPENFIRE_DIR}/lib/startup.jar ${EXTRA_ARGS}
 else

--- a/plugins/pom.xml
+++ b/plugins/pom.xml
@@ -97,6 +97,7 @@
         <module>openfire-voice-plugin</module>
         <module>openfire-apns</module>
         <module>openfire-hazelcast-plugin</module>
+        <module>openfire-registration-plugin</module>
     </modules>
 
     <organization>


### PR DESCRIPTION
- use our registration plugin not the official one
- starting Openfire now with SSL enabled
- have the Project folder as a build argument for local Docker build