### PR TITLE
Updated deployment to only work on tag push

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,9 +6,6 @@ on:
   push:
     tags:
       - '*'
-    branches:
-      - master
-      - main
 
 # one job and step to deploy
 jobs:


### PR DESCRIPTION
The current GitHub workflow for deployment also works on branch push which is not what we want here.